### PR TITLE
More work on metal

### DIFF
--- a/examples/image_classification/mnist/Cargo.toml
+++ b/examples/image_classification/mnist/Cargo.toml
@@ -5,9 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-deltaml = { path = "../../../delta" }
+deltaml = { path = "../../../delta", features = ["metal"] }
 tokio = { workspace = true, features = ["full"] }
-
-[features]
-default = []
-metal = ["deltaml/metal"]

--- a/examples/image_classification/mnist/src/main.rs
+++ b/examples/image_classification/mnist/src/main.rs
@@ -7,7 +7,6 @@ use deltaml::neuralnet::Sequential;
 use deltaml::neuralnet::{Dense, Flatten};
 use deltaml::optimizers::Adam;
 
-#[cfg(feature = "metal")]
 use deltaml::devices::{Device, osx_metal};
 
 #[tokio::main]
@@ -37,7 +36,6 @@ async fn main() {
     #[allow(unused_mut)]
     let mut val_data = MnistDataset::load_val().await;
 
-    #[cfg(feature = "metal")]
     {
         println!("Transferring data to Metal device.");
         let (metal_device, metal_queue) = osx_metal::get_device_and_queue_metal();


### PR DESCRIPTION
Removed CFG on mnist example since we active this feature by setting the feature flag on the deltaml dependency. That's how it should work. We only use CFG in the delta library for things as you already did and active each feature by setting them in the dependency section. You will understand when you see the changes here.