### PR TITLE
142 adam optimizer performance improvements

### DIFF
--- a/delta/src/common/tensor_ops.rs
+++ b/delta/src/common/tensor_ops.rs
@@ -712,15 +712,19 @@ impl Tensor {
     pub fn to_device(&mut self, device: Device) -> Result<Self, String> {
         self.device = device.clone();
         Ok(self.clone())
-        // match device {
-        //     Device::Cpu => Ok(self.clone()), // Already on CPU
-        //     #[cfg(feature = "metal")]
-        //     Device::Metal { device, queue } => {
-        //         let buffer = to_device_metal(self, &device, &queue)?;
-        //         Ok(from_device_metal(&buffer, self.shape()))
-        //     }
-        //     _ => Err("Device not supported yet.".to_string()),
-        // }
+    }
+
+    /// Scales the tensor by a scalar value.
+    ///
+    /// # Arguments
+    ///
+    /// * `scalar` - The scalar value to scale the tensor by.
+    ///
+    /// # Returns
+    ///
+    /// A new tensor containing the scaled values.
+    pub fn scale(&self, scalar: f32) -> Tensor {
+        self.map(|x| x * scalar)
     }
 }
 
@@ -1049,5 +1053,15 @@ mod tests {
         let tensor2 = Tensor::new(vec![4.0, 5.0, 6.0], Shape::from(IxDyn(&[3])));
         let result = tensor1.sub(&tensor2);
         assert_eq!(result.data.shape(), &[3]);
+    }
+
+    #[test]
+    fn test_scale() {
+        let data = vec![1.0, 2.0, 3.0, 4.0];
+        let tensor = Tensor::new(data, Shape::from(IxDyn(&[2, 2])));
+        let scaled = tensor.scale(2.0);
+
+        assert_eq!(scaled.data.shape(), &[2, 2]);
+        assert_eq!(scaled.to_vec(), vec![2.0, 4.0, 6.0, 8.0]);
     }
 }

--- a/delta/src/common/tensor_ops.rs
+++ b/delta/src/common/tensor_ops.rs
@@ -45,12 +45,13 @@ impl Tensor {
     /// # Arguments
     ///
     /// * `shape` - A vector representing the shape of the tensor.
+    /// * `device` - The device to create the tensor on.
     ///
     /// # Returns
     ///
     /// A tensor filled with zeros.
-    pub fn zeros(shape: Shape<IxDyn>) -> Self {
-        Self { data: Array::zeros(shape), device: Device::default() }
+    pub fn zeros(shape: Shape<IxDyn>, device: Device) -> Self {
+        Self { data: Array::zeros(shape), device }
     }
 
     /// Creates a tensor filled with random values.
@@ -417,7 +418,7 @@ impl Tensor {
         let current_max = self.data.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
 
         if current_min == current_max {
-            return Tensor::zeros(self.shape());
+            return Tensor::zeros(self.shape(), self.device.clone());
         }
 
         let normalized_data =
@@ -752,7 +753,7 @@ impl Default for Tensor {
     ///
     /// A new tensor with default values.
     fn default() -> Self {
-        Self::zeros(Shape::from(IxDyn(&[1, 1])))
+        Self::zeros(Shape::from(IxDyn(&[1, 1])), Device::Cpu)
     }
 }
 
@@ -804,7 +805,7 @@ mod tests {
     #[test]
     fn test_zeros() {
         let shape = Shape::from(IxDyn(&[2, 3]));
-        let tensor = Tensor::zeros(shape);
+        let tensor = Tensor::zeros(shape, Device::default());
         assert_eq!(tensor.data.shape(), &[2, 3]);
     }
 

--- a/delta/src/devices/osx_metal.rs
+++ b/delta/src/devices/osx_metal.rs
@@ -29,67 +29,7 @@
 
 use crate::common::Tensor;
 pub use metal;
-use ndarray::{Array, IxDyn, Shape};
-
-/// Transfers the tensor to a Metal device.
-///
-/// # Arguments
-///
-/// * `metal_device` - The Metal device to transfer the tensor to.
-///
-/// # Returns
-///
-/// A new tensor with data stored on the Metal device.
-#[cfg(feature = "metal")]
-pub fn to_device_metal(
-    tensor: &Tensor,
-    metal_device: &metal::Device,
-    _queue: &metal::CommandQueue,
-) -> Result<metal::Buffer, String> {
-    // Create a Metal buffer for the tensor's data
-    let tensor_size = tensor.data.len() * std::mem::size_of::<f32>();
-    let buffer =
-        metal_device.new_buffer(tensor_size as u64, metal::MTLResourceOptions::StorageModeShared);
-
-    // Copy the tensor's data into the Metal buffer
-    unsafe {
-        std::ptr::copy_nonoverlapping(
-            tensor.data.as_slice().unwrap().as_ptr(),
-            buffer.contents() as *mut f32,
-            tensor.data.len(),
-        );
-    }
-
-    Ok(buffer)
-}
-
-/// Transfers the tensor's data back from a Metal buffer to the CPU.
-///
-/// # Arguments
-///
-/// * `buffer` - The Metal buffer containing the tensor's data.
-///
-/// # Returns
-///
-/// A new `Tensor` instance with the data transferred from the Metal device.
-#[cfg(feature = "metal")]
-pub fn from_device_metal(buffer: &metal::Buffer, shape: Shape<IxDyn>) -> Tensor {
-    // Create a vector to hold the data
-    let tensor_size = buffer.length() as usize / std::mem::size_of::<f32>();
-    let mut data = vec![0.0; tensor_size];
-
-    // Copy the data from the Metal buffer
-    unsafe {
-        std::ptr::copy_nonoverlapping(
-            buffer.contents() as *const f32,
-            data.as_mut_ptr(),
-            tensor_size,
-        );
-    }
-
-    // Create a new tensor from the data
-    Tensor::new(data, shape)
-}
+use ndarray::Array;
 
 /// Creates a Metal device and command queue.
 ///

--- a/delta/src/neuralnet/layers/dense.rs
+++ b/delta/src/neuralnet/layers/dense.rs
@@ -113,7 +113,7 @@ impl Layer for Dense {
         ));
 
         // Initialize bias to zeros
-        self.bias = Some(Tensor::zeros(Shape::from(IxDyn(&[self.units]))));
+        self.bias = Some(Tensor::zeros(Shape::from(IxDyn(&[self.units])), self.device.clone()));
 
         Ok(())
     }

--- a/delta/src/optimizers/ada_delta.rs
+++ b/delta/src/optimizers/ada_delta.rs
@@ -82,23 +82,15 @@ impl Optimizer for AdaDelta {
             || self.accumulated_gradients.as_ref().unwrap().shape().raw_dim()
                 != weights.shape().raw_dim()
         {
-            self.accumulated_gradients = Some(Tensor::zeros(weights.shape().clone()));
-            self.accumulated_gradients = Some(
-                self.accumulated_gradients
-                    .as_mut()
-                    .unwrap()
-                    .to_device(self.device.clone())
-                    .unwrap(),
-            );
+            self.accumulated_gradients =
+                Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
         }
         if self.accumulated_updates.is_none()
             || self.accumulated_updates.as_ref().unwrap().shape().raw_dim()
                 != weights.shape().raw_dim()
         {
-            self.accumulated_updates = Some(Tensor::zeros(weights.shape().clone()));
-            self.accumulated_updates = Some(
-                self.accumulated_updates.as_mut().unwrap().to_device(self.device.clone()).unwrap(),
-            );
+            self.accumulated_updates =
+                Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
         }
 
         let accumulated_gradients = self.accumulated_gradients.as_mut().unwrap();

--- a/delta/src/optimizers/ada_grad.rs
+++ b/delta/src/optimizers/ada_grad.rs
@@ -84,8 +84,7 @@ impl Optimizer for AdaGrad {
         if self.g_sum.is_none()
             || self.g_sum.as_ref().unwrap().shape().raw_dim() != weights.shape().raw_dim()
         {
-            self.g_sum = Some(Tensor::zeros(weights.shape().clone()));
-            self.g_sum = Some(self.g_sum.as_mut().unwrap().to_device(self.device.clone()).unwrap());
+            self.g_sum = Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
         }
 
         let g_sum = self.g_sum.as_mut().unwrap();

--- a/delta/src/optimizers/rms_prop.rs
+++ b/delta/src/optimizers/rms_prop.rs
@@ -94,9 +94,7 @@ impl Optimizer for RMSProp {
 
         // Initialize mean square tensor if not already done
         if self.mean_square.is_none() {
-            self.mean_square = Some(Tensor::zeros(weights.shape().clone()));
-            self.mean_square =
-                Some(self.mean_square.as_mut().unwrap().to_device(self.device.clone()).unwrap());
+            self.mean_square = Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
         }
 
         let mean_square = self.mean_square.as_mut().unwrap();

--- a/delta/src/optimizers/sgd_momentum.rs
+++ b/delta/src/optimizers/sgd_momentum.rs
@@ -50,9 +50,7 @@ impl Optimizer for SGDWithMomentum {
         if self.velocity.is_none()
             || self.velocity.as_ref().unwrap().shape().raw_dim() != weights.shape().raw_dim()
         {
-            self.velocity = Some(Tensor::zeros(weights.shape().clone()));
-            self.velocity =
-                Some(self.velocity.as_mut().unwrap().to_device(self.device.clone()).unwrap());
+            self.velocity = Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
         }
 
         let velocity = self.velocity.as_mut().unwrap();


### PR DESCRIPTION
Add an explicit scale function to the tensor
Optimize the to_device logic for Tensor::Zeros
Finally, reduce the amount of operations in the Adam optimizer. It at least shaves a 15-20 seconds per Epoch