### PR TITLE
Fix Softmax activation to be computed row-wise for correct per-batch …

### DIFF
--- a/delta/src/activations/softmax.rs
+++ b/delta/src/activations/softmax.rs
@@ -60,20 +60,34 @@ impl Activation for SoftmaxActivation {
     ///
     /// The output tensor after applying the Softmax activation function.
     fn activate(&self, input: &Tensor) -> Tensor {
-        // Find the maximum value in the input tensor
-        let max_value = input.max();
-
-        // Subtract the maximum value from each element in the input tensor
-        let stabilized_input = input.map(|x| x - max_value);
-
-        // Compute the exponentials
-        let exps = stabilized_input.map(|x| x.exp());
-
-        // Compute the sum of the exponentials
-        let sum: f32 = exps.data.iter().sum();
-
-        // Normalize to get the softmax probabilities
-        exps.map(|x| x / sum)
+        let shape = &input.data.shape();
+        let batch_size = shape[0];
+        let num_classes = shape[1];
+        
+        // We'll build a new Vec for the output data
+        let mut output_data = Vec::with_capacity(batch_size * num_classes);
+        
+        for b in 0..batch_size {
+            // Extract the row
+            let row = input.data.slice(s![b, ..]);
+        
+            // Find the row-wise max for numerical stability
+            let max_in_row = row.fold(std::f32::MIN, |acc, &x| acc.max(x));
+        
+            // Exponentiate each element minus that row-wise max
+            let exps: Vec<f32> = row.iter().map(|&x| (x - max_in_row).exp()).collect();
+        
+            // Sum the exponentials
+            let sum_of_exps: f32 = exps.iter().sum();
+        
+            // Normalize each element by the sum of exponentials
+            for val in exps.iter() {
+                output_data.push(val / sum_of_exps);
+            }
+        }
+        
+        // Return a new Tensor with the same shape
+        Tensor::new(output_data, input.data.shape().clone())
     }
 
     /// Computes the Jacobian of the Softmax function.

--- a/delta/src/activations/softmax.rs
+++ b/delta/src/activations/softmax.rs
@@ -87,7 +87,7 @@ impl Activation for SoftmaxActivation {
         }
         
         // Return a new Tensor with the same shape
-        Tensor::new(output_data, input.data.shape().clone())
+        Tensor::new(output_data, Shape::from(IxDyn(&[batch_size, num_classes])))
     }
 
     /// Computes the Jacobian of the Softmax function.


### PR DESCRIPTION
This Pull Request fixes a bug in the `SoftmaxActivation` where the softmax operation was inadvertently stabilized by a single global maximum across all rows, which led to incorrect outputs for multi-row (`batch_size > 1`) inputs.

### Problem
- Previously, the code subtracted the maximum value found over the entire 2D tensor. This worked fine when `batch_size = 1` but would cause problems with larger batches, because only the row containing that global max was numerically stable.
- Other rows were offset by that same max (potentially very different from their actual row-wise maxima) which would lead to skewed probabilities.

### Fix
- Compute the max value **per row**, then exponentiate and normalize **each row** independently.

### Changes
1. **Softmax Activation**  
   - Introduced a loop over each row in the input tensor.
   - Per row:
     - Compute the row-wise max.
     - Exponentiate all elements (after subtracting this row max).
     - Normalize by dividing each exponentiated element by the row-wise sum.