### PR TITLE
Fix MNIST test_parse_images

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -85,6 +85,24 @@ jobs:
             ~/.cargo
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Download and Cache MNIST
+        uses: actions/cache@v4
+        id: mnist-cache
+        with:
+          path: ~/.cache/dataset/mnist
+          key: ${{ runner.os }}-mnist-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Download MNIST Data
+        if: steps.mnist-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.cache/dataset/mnist
+          cd ~/.cache/dataset/mnist
+
+          curl -L -O https://storage.googleapis.com/cvdf-datasets/mnist/train-images-idx3-ubyte.gz
+          curl -L -O https://storage.googleapis.com/cvdf-datasets/mnist/train-labels-idx1-ubyte.gz
+          curl -L -O https://storage.googleapis.com/cvdf-datasets/mnist/t10k-images-idx3-ubyte.gz
+          curl -L -O https://storage.googleapis.com/cvdf-datasets/mnist/t10k-labels-idx1-ubyte.gz
+
       - name: Run Tests
         run: cargo test 
 


### PR DESCRIPTION
Fixes #131.

Download and cache MNIST data prior to running tests.
This hopefully ensures stable test runs by preventing “corrupt deflate stream” errors caused by incomplete downloads.

I've tried to rerun the tests 5 times without any issues so far.