### PR TITLE
github/workflows: update Github Actions

### DIFF
--- a/.github/workflows/github_actions_update.yaml
+++ b/.github/workflows/github_actions_update.yaml
@@ -1,0 +1,55 @@
+name: github actions update
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.DELTA_BOT_GH_TOKEN }}
+
+      - name: Update GitHub Actions
+        id: updater
+        uses: saadmk11/github-actions-version-updater@v0.8.1
+        with:
+          token: ${{ secrets.DELTA_BOT_GH_TOKEN }}
+          skip_pull_request: 'true'
+
+      - name: Check for Changes
+        id: check_changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changes_detected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes_detected=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Branch, Commit and Push
+        if: ${{ steps.check_changes.outputs.changes_detected == 'true' }}
+        id: commit_push
+        run: |
+          BRANCH_NAME="update-github-actions-$(date +%Y%m%d%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+          git config --global user.name "dmlops"
+          git config --global user.email "deltaml@icloud.com"
+          git add .
+          git commit -m "Update GitHub Actions"
+          git push "https://x-access-token:${{ secrets.DELTA_BOT_GH_TOKEN }}@github.com/${{ github.repository }}" "$BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Create and Merge Pull Request
+        if: ${{ steps.check_changes.outputs.changes_detected == 'true' }}
+        run: |
+          DIFF=$(git diff HEAD~1 HEAD || true)
+          PR_BODY="Bump GitHub Actions versions\n\n\`\`\`diff\n$DIFF\n\`\`\`"
+          PR_URL=$(gh pr create --base master --head "${{ steps.commit_push.outputs.branch_name }}" --title "Update GitHub Actions" --body "$PR_BODY" --draft=false --label "dependencies")
+          gh pr merge "$PR_URL" --merge --delete-branch


### PR DESCRIPTION
There's a few deprecation notices that seem to stem from using outdated Github Actions. By using Dependabot we can stay updated and use the latest versions.