### PR TITLE
github/workflows/github_actions_update: Continue on error

### DIFF
--- a/.github/workflows/github_actions_update.yaml
+++ b/.github/workflows/github_actions_update.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           token: ${{ secrets.DELTA_BOT_GH_TOKEN }}
           skip_pull_request: 'true'
-        continue-on-error: true # skip_pull_request exits with 1 if changes are detected and pull request is not created
+        continue-on-error: true # skip_pull_request exits with code 1 if changes are detected and pull request is not created
 
       - name: Check for Changes
         id: check_changes

--- a/.github/workflows/github_actions_update.yaml
+++ b/.github/workflows/github_actions_update.yaml
@@ -23,6 +23,7 @@ jobs:
         with:
           token: ${{ secrets.DELTA_BOT_GH_TOKEN }}
           skip_pull_request: 'true'
+        continue-on-error: true # skip_pull_request exits with 1 if changes are detected and pull request is not created
 
       - name: Check for Changes
         id: check_changes


### PR DESCRIPTION
`skip_pull_request` exits with code >0 if changes are detected and pull request is not created.

See https://github.com/delta-rs/delta/actions/runs/12521554549/job/34928769295#step:4:91.