### PR TITLE
github/workflows/core: Use GitHub/Cargo workspace for caching MNIST dataset

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -89,22 +89,21 @@ jobs:
         uses: actions/cache@v4
         id: mnist-cache
         with:
-          path: ~/.cache/dataset/mnist
+          path: ${{ github.workspace }}/.cache/dataset/mnist
           key: ${{ runner.os }}-mnist-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Download MNIST Data
         if: steps.mnist-cache.outputs.cache-hit != 'true'
         run: |
-          mkdir -p ~/.cache/dataset/mnist
-          cd ~/.cache/dataset/mnist
-
+          mkdir -p .cache/dataset/mnist
+          cd .cache/dataset/mnist
           curl -L -O https://storage.googleapis.com/cvdf-datasets/mnist/train-images-idx3-ubyte.gz
           curl -L -O https://storage.googleapis.com/cvdf-datasets/mnist/train-labels-idx1-ubyte.gz
           curl -L -O https://storage.googleapis.com/cvdf-datasets/mnist/t10k-images-idx3-ubyte.gz
           curl -L -O https://storage.googleapis.com/cvdf-datasets/mnist/t10k-labels-idx1-ubyte.gz
 
       - name: Run Tests
-        run: cargo test 
+        run: cargo test
 
   coverage:
     name: Code Coverage

--- a/delta/Cargo.toml
+++ b/delta/Cargo.toml
@@ -29,6 +29,7 @@ image = "0.25.5"
 serial_test = "3.2"
 rand_distr = "0.4.3"
 libm = "0.2.11"
+directories = "5.0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = { version = "0.30.0", optional = true }

--- a/delta/Cargo.toml
+++ b/delta/Cargo.toml
@@ -29,7 +29,6 @@ image = "0.25.5"
 serial_test = "3.2"
 rand_distr = "0.4.3"
 libm = "0.2.11"
-directories = "5.0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = { version = "0.30.0", optional = true }

--- a/delta/src/dataset/image/mnist.rs
+++ b/delta/src/dataset/image/mnist.rs
@@ -175,6 +175,13 @@ impl MnistDataset {
         debug!("Downloading MNIST dataset from {}", &url);
 
         let response = reqwest::get(&url).await.map_err(|e| e.to_string())?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "Request failed with status: {} for URL: {}",
+                response.status(),
+                url
+            ));
+        }
         let compressed_data = response.bytes().await.map_err(|e| e.to_string())?;
 
         async_fs::create_dir_all(format!("{}/.cache/dataset/mnist", workspace_dir.display()))

--- a/delta/src/dataset/image/mnist.rs
+++ b/delta/src/dataset/image/mnist.rs
@@ -168,6 +168,7 @@ impl MnistDataset {
         let file_path = format!("{}/.cache/dataset/mnist/{}", workspace_dir.display(), filename);
 
         if Path::new(&file_path).exists() {
+            debug!("Using cached file: {}", &file_path);
             return Self::decompress_gz(&file_path).map_err(|e| e.to_string());
         }
 

--- a/delta/src/dataset/image/mnist.rs
+++ b/delta/src/dataset/image/mnist.rs
@@ -30,10 +30,9 @@
 use std::fs::File;
 use std::future::Future;
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::Path;
 use std::pin::Pin;
 
-use directories::BaseDirs;
 use flate2::read::GzDecoder;
 use log::debug;
 use ndarray::{IxDyn, Shape};
@@ -43,27 +42,13 @@ use tokio::fs as async_fs;
 
 use crate::common::Tensor;
 use crate::dataset::base::{Dataset, ImageDatasetOps};
+use crate::get_workspace_dir;
 
 /// A struct representing the MNIST dataset.
 pub struct MnistDataset {
     train: Option<Dataset>,
     test: Option<Dataset>,
     val: Option<Dataset>,
-}
-
-/// Returns the cache directory path where we store the MNIST dataset.
-///
-/// This uses dataset/mnist in the system’s cache directory if available.
-/// If the directories crate cannot find the base cache directory, it uses ./dataset/mnist.
-fn get_cache_dir() -> PathBuf {
-    if let Some(base_dirs) = BaseDirs::new() {
-        let mut cache_path = base_dirs.cache_dir().to_path_buf();
-        cache_path.push("dataset");
-        cache_path.push("mnist");
-        cache_path
-    } else {
-        PathBuf::from("./dataset/mnist")
-    }
 }
 
 impl MnistDataset {
@@ -179,41 +164,25 @@ impl MnistDataset {
     /// # Returns
     /// A vector containing the decompressed dataset
     async fn get_bytes_data(filename: &str) -> Result<Vec<u8>, String> {
-        let cache_dir = get_cache_dir();
-        let file_path = cache_dir.join(filename);
+        let workspace_dir = get_workspace_dir();
+        let file_path = format!("{}/.cache/dataset/mnist/{}", workspace_dir.display(), filename);
 
-        if file_path.exists() {
-            debug!("Using cached file: {:?}", file_path);
-            return Self::decompress_gz(file_path.to_str().unwrap()).map_err(|e| e.to_string());
+        if Path::new(&file_path).exists() {
+            return Self::decompress_gz(&file_path).map_err(|e| e.to_string());
         }
 
         let url = format!("{}/{}", Self::MNIST_URL, filename);
         debug!("Downloading MNIST dataset from {}", &url);
 
-        let client = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::limited(1))
-            .build()
-            .map_err(|e| e.to_string())?;
+        let response = reqwest::get(&url).await.map_err(|e| e.to_string())?;
+        let compressed_data = response.bytes().await.map_err(|e| e.to_string())?;
 
-        let response = client
-            .get(&url)
-            .send()
+        async_fs::create_dir_all(format!("{}/.cache/dataset/mnist", workspace_dir.display()))
             .await
             .map_err(|e| e.to_string())?;
-
-        if !response.status().is_success() {
-            return Err(format!(
-                "Request failed with status: {} for URL: {}",
-                response.status(),
-                url
-            ));
-        }
-
-        let compressed_data = response.bytes().await.map_err(|e| e.to_string())?;
-        async_fs::create_dir_all(&cache_dir).await.map_err(|e| e.to_string())?;
         async_fs::write(&file_path, &compressed_data).await.map_err(|e| e.to_string())?;
 
-        Self::decompress_gz(file_path.to_str().unwrap()).map_err(|e| e.to_string())
+        Self::decompress_gz(&file_path).map_err(|e| e.to_string())
     }
 
     /// Decompresses a gzip file.
@@ -524,9 +493,10 @@ mod tests {
     use super::*;
 
     fn setup() {
-        let cache_dir = get_cache_dir();
-        if cache_dir.exists() {
-            fs::remove_dir_all(&cache_dir).expect("Failed to delete cache directory");
+        let workspace_dir = get_workspace_dir();
+        let cache_path = format!("{}/.cache/dataset/mnist", workspace_dir.display());
+        if Path::new(&cache_path).exists() {
+            fs::remove_dir_all(&cache_path).expect("Failed to delete cache directory");
         }
     }
 
@@ -537,9 +507,10 @@ mod tests {
         let rt = Runtime::new().unwrap();
         rt.block_on(async {
             let _ = MnistDataset::load_data(true).await;
-            let cache_dir = get_cache_dir();
+            let workspace_dir = get_workspace_dir();
+            let cache_path = format!("{}/.cache/dataset/mnist", workspace_dir.display());
             assert!(
-                cache_dir.exists(),
+                Path::new(&cache_path).exists(),
                 "MNIST dataset should be downloaded and extracted"
             );
         });


### PR DESCRIPTION
The cache in Github Actions gets stored in the XDG home directory. I think it makes sense to use the same directory for tests?