### PR TITLE
Parallelize tensor operations and cleanup Adam optimizer

### DIFF
--- a/delta/Cargo.toml
+++ b/delta/Cargo.toml
@@ -29,6 +29,7 @@ image = "0.25.5"
 serial_test = "3.2"
 rand_distr = "0.4.3"
 libm = "0.2.11"
+rayon = "1.10.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = { version = "0.30.0", optional = true }

--- a/delta/src/lib.rs
+++ b/delta/src/lib.rs
@@ -46,8 +46,9 @@ pub mod optimizers;
 ///
 /// A `PathBuf` representing the path to the workspace directory.
 pub fn get_workspace_dir() -> PathBuf {
-    let mut path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    // Add a default for flamegraph's to work
+    let path = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    let mut path = PathBuf::from(path);
     path.pop();
-
     path
 }

--- a/delta/src/neuralnet/layers/dense.rs
+++ b/delta/src/neuralnet/layers/dense.rs
@@ -115,7 +115,7 @@ impl Layer for Dense {
         ));
 
         // Initialize bias to zeros
-        self.bias = Some(Tensor::zeros(Shape::from(IxDyn(&[self.units]))));
+        self.bias = Some(Tensor::zeros(Shape::from(IxDyn(&[self.units])), self.device.clone()));
 
         Ok(())
     }

--- a/delta/src/optimizers/ada_delta.rs
+++ b/delta/src/optimizers/ada_delta.rs
@@ -82,7 +82,8 @@ impl Optimizer for AdaDelta {
             || self.accumulated_gradients.as_ref().unwrap().shape().raw_dim()
                 != weights.shape().raw_dim()
         {
-            self.accumulated_gradients = Some(Tensor::zeros(weights.shape().clone()));
+            self.accumulated_gradients =
+                Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
             self.accumulated_gradients = Some(
                 self.accumulated_gradients
                     .as_mut()
@@ -95,7 +96,8 @@ impl Optimizer for AdaDelta {
             || self.accumulated_updates.as_ref().unwrap().shape().raw_dim()
                 != weights.shape().raw_dim()
         {
-            self.accumulated_updates = Some(Tensor::zeros(weights.shape().clone()));
+            self.accumulated_updates =
+                Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
             self.accumulated_updates = Some(
                 self.accumulated_updates.as_mut().unwrap().to_device(self.device.clone()).unwrap(),
             );

--- a/delta/src/optimizers/ada_grad.rs
+++ b/delta/src/optimizers/ada_grad.rs
@@ -85,8 +85,7 @@ impl Optimizer for AdaGrad {
         if self.g_sum.is_none()
             || self.g_sum.as_ref().unwrap().shape().raw_dim() != weights.shape().raw_dim()
         {
-            self.g_sum = Some(Tensor::zeros(weights.shape().clone()));
-            self.g_sum = Some(self.g_sum.as_mut().unwrap().to_device(self.device.clone()).unwrap());
+            self.g_sum = Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
         }
 
         let g_sum = self.g_sum.as_mut().unwrap();

--- a/delta/src/optimizers/rms_prop.rs
+++ b/delta/src/optimizers/rms_prop.rs
@@ -94,9 +94,7 @@ impl Optimizer for RMSProp {
 
         // Initialize mean square tensor if not already done
         if self.mean_square.is_none() {
-            self.mean_square = Some(Tensor::zeros(weights.shape().clone()));
-            self.mean_square =
-                Some(self.mean_square.as_mut().unwrap().to_device(self.device.clone()).unwrap());
+            self.mean_square = Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
         }
 
         let mean_square = self.mean_square.as_mut().unwrap();

--- a/delta/src/optimizers/sgd_momentum.rs
+++ b/delta/src/optimizers/sgd_momentum.rs
@@ -50,9 +50,7 @@ impl Optimizer for SGDWithMomentum {
         if self.velocity.is_none()
             || self.velocity.as_ref().unwrap().shape().raw_dim() != weights.shape().raw_dim()
         {
-            self.velocity = Some(Tensor::zeros(weights.shape().clone()));
-            self.velocity =
-                Some(self.velocity.as_mut().unwrap().to_device(self.device.clone()).unwrap());
+            self.velocity = Some(Tensor::zeros(weights.shape().clone(), self.device.clone()));
         }
 
         let velocity = self.velocity.as_mut().unwrap();

--- a/delta_bench/README.md
+++ b/delta_bench/README.md
@@ -1,0 +1,3 @@
+# Delta Bench
+
+To run the various bencharks, run `cargo bench`


### PR DESCRIPTION
This PR does the following:
 - Add Rayon to parallelize scalar operations
 - Require device to be added to Tensor::Zeros
 - Move initialize_moving_averages into it's own function for readability